### PR TITLE
Add simple local reporter

### DIFF
--- a/benchmarking/get_connected_androids.py
+++ b/benchmarking/get_connected_androids.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+##############################################################################
+# Copyright 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+
+from platforms.android.android_driver import AndroidDriver
+from utils.arg_parse import getParser, parse
+
+
+getParser().add_argument("-d", "--devices",
+    help="Specify the devices to run the benchmark, in a comma separated "
+    "list. The value is the device or device_hash field of the meta info.")
+getParser().add_argument("--device",
+    help="The single device to run this benchmark on")
+getParser().add_argument("--excluded_devices",
+    help="Specify the devices that skip the benchmark, in a comma separated "
+    "list. The value is the device or device_hash field of the meta info.")
+getParser().add_argument("--set_freq",
+    help="On rooted android phones, set the frequency of the cores. "
+    "The supported values are: "
+    "max: set all cores to the maximum frquency. "
+    "min: set all cores to the minimum frequency. "
+    "mid: set all cores to the median frequency. ")
+
+
+class GetConnectedAndroids(object):
+    def __init__(self):
+        parse()
+
+    def run(self):
+        driver = AndroidDriver()
+        platforms = driver.getAndroidPlatforms("")
+        androids = {}
+        for p in platforms:
+            androids[p.platform] = p.platform_hash
+        json_str = json.dumps(androids)
+        print(json_str)
+        return json_str
+
+
+if __name__ == "__main__":
+    app = GetConnectedAndroids()
+    app.run()

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -39,9 +39,13 @@ getParser().add_argument("--info", required=True,
     help="The json serialized options describing the control and treatment.")
 getParser().add_argument("--local_reporter",
     help="Save the result to a directory specified by this argument.")
+getParser().add_argument("--simple_local_reporter",
+    help="Same as local reporter, but the directory hierarchy is reduced.")
 getParser().add_argument("--model_cache", required=True,
     help="The local directory containing the cached models. It should not "
     "be part of a git directory.")
+getParser().add_argument("--device",
+    help="The single device to run this benchmark on")
 getParser().add_argument("-p", "--platform", required=True,
     help="Specify the platform to benchmark on. Use this flag if the framework"
     " needs special compilation scripts. The scripts are called build.sh "

--- a/benchmarking/platforms/android/android_driver.py
+++ b/benchmarking/platforms/android/android_driver.py
@@ -34,9 +34,14 @@ class AndroidDriver:
         return devices
 
     def getAndroidPlatforms(self, tempdir):
+        platforms = []
+        if getArgs().device:
+            adb = ADB(getArgs().device)
+            platforms.append(AndroidPlatform(tempdir, adb))
+            return platforms
+
         if self.devices is None:
             self.devices = self.getDevices()
-        platforms = []
         if getArgs().excluded_devices:
             excluded_devices = \
                 set(getArgs().excluded_devices.strip().split(','))

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -31,8 +31,6 @@ class AndroidPlatform(PlatformBase):
             '-' + \
             adb.shell(['getprop', 'ro.build.version.sdk'], default="").strip()
         self.setPlatform(platform)
-        self.tempdir = tempdir + "/" + self.platform
-        os.makedirs(self.tempdir, 0o777, True)
         self.platform_hash = adb.device
         self._setLogCatSize()
         if getArgs().set_freq:

--- a/benchmarking/reporters/reporters.py
+++ b/benchmarking/reporters/reporters.py
@@ -11,6 +11,7 @@
 from utils.arg_parse import getArgs
 from .local_reporter.local_reporter import LocalReporter
 from .remote_reporter.remote_reporter import RemoteReporter
+from .simple_local_reporter.simple_local_reporter import SimpleLocalReporter
 from .screen_reporter.screen_reporter import ScreenReporter
 
 
@@ -18,6 +19,8 @@ def getReporters():
     reporters = []
     if getArgs().local_reporter:
         reporters.append(LocalReporter())
+    if getArgs().simple_local_reporter:
+        reporters.append(SimpleLocalReporter())
     if getArgs().remote_reporter:
         reporters.append(RemoteReporter())
     if getArgs().screen_reporter:

--- a/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
+++ b/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3.6
+
+##############################################################################
+# Copyright 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+from reporters.reporter_base import ReporterBase
+from utils.arg_parse import getArgs
+from utils.custom_logger import getLogger
+from utils.utilities import getFilename
+
+import json
+import os
+
+
+class SimpleLocalReporter(ReporterBase):
+    def __init__(self):
+        super(SimpleLocalReporter, self).__init__()
+
+    def report(self, content):
+        data = content[self.DATA]
+        if data is None or len(data) == 0:
+            getLogger().info("No data to write")
+            return
+        meta = content[self.META]
+        id_dir = getFilename(meta["identifier"]) + "/"
+        dirname = id_dir
+        dirname = getArgs().simple_local_reporter + "/" + dirname
+        assert not os.path.exists(dirname), \
+            "Simple local reporter should not have multiple entries"
+        os.makedirs(dirname)
+        with open(dirname + "/data.txt", 'w') as file:
+            content_d = json.dumps(data)
+            file.write(content_d)
+        platform_name = meta[self.PLATFORM]
+        pname = platform_name
+        if "platform_hash" in meta:
+            pname = pname + " ({})".format(meta["platform_hash"])
+        getLogger().info("Writing file for {}: {}".format(pname, dirname))


### PR DESCRIPTION
Create simple local reporter, which doesn't have long directory hierarchies. Also add an argument --device. When specified, the device is used instead of querying all existing devices