### PR TITLE
Reapply reverted changes to benchmark_driver.py in #21

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -37,7 +37,7 @@ def runOneBenchmark(info, benchmark, framework, platform,
             data = _mergeDelayData(data, control, bname)
         if benchmark["tests"][0]["metric"] != "generic":
             data = _adjustData(info, data)
-            meta = _retrieveMeta(info, benchmark, platform, framework, backend)
+        meta = _retrieveMeta(info, benchmark, platform, framework, backend)
 
         result = {
             "meta": meta,
@@ -220,33 +220,43 @@ def _adjustData(info, data):
 
 def _retrieveMeta(info, benchmark, platform, framework, backend):
     assert "treatment" in info, "Treatment is missing in info"
-    model = benchmark["model"]
-    test = benchmark["tests"][0]
+
     meta = {}
+    # common
+    meta["backend"] = backend
     meta["time"] = time.time()
-    meta['net_name'] = model["name"]
-    meta["metric"] = test["metric"]
     meta["framework"] = framework.getName()
     meta["platform"] = platform.getName()
     if platform.platform_hash:
         meta["platform_hash"] = platform.platform_hash
+    meta["command"] = sys.argv
+    meta["command_str"] = getCommand(sys.argv)
+    if getArgs().user_identifier:
+        meta["user_identifier"] = getArgs().user_identifier
+
+    # model specific
+    if "model" in benchmark:
+        model = benchmark["model"]
+        meta['net_name'] = model["name"]
+        if "group" in benchmark["model"]:
+            meta["group"] = benchmark["model"]["group"]
+
+    # test specific
+    test = benchmark["tests"][0]
+    meta["metric"] = test["metric"]
     if "identifier" in test:
         meta["identifier"] = test["identifier"]
     else:
         meta["identifier"] = meta["net_name"]
-    assert "commit" in info["treatment"], \
-        "Commit hash is missing in treatment"
-    meta["commit"] = info["treatment"]["commit"]
-    meta["commit_time"] = info["treatment"]["commit_time"]
+
+    # info specific
+    if "commit" in info["treatment"]:
+        meta["commit"] = info["treatment"]["commit"]
+        meta["commit_time"] = info["treatment"]["commit_time"]
     if "control" in info:
         meta["control_commit"] = info["control"]["commit"]
         meta["control_commit_time"] = info["control"]["commit_time"]
-    meta["run_type"] = info["run_type"]
-    meta["command"] = sys.argv
-    meta["command_str"] = getCommand(sys.argv)
-    if "group" in benchmark["model"]:
-        meta["group"] = benchmark["model"]["group"]
-    meta["backend"] = backend
-    if getArgs().user_identifier:
-        meta["user_identifier"] = getArgs().user_identifier
+    if "run_type" in info:
+        meta["run_type"] = info["run_type"]
+
     return meta

--- a/benchmarking/frameworks/generic/generic.py
+++ b/benchmarking/frameworks/generic/generic.py
@@ -44,7 +44,6 @@ class GenericFramework(FrameworkBase):
                            for name in model["files"]}
             model_files = \
                 platform.copyFilesToPlatform(model_files)
-            commands = self._updateModelPath(model, commands)
 
         # todo: input files
 
@@ -63,13 +62,3 @@ class GenericFramework(FrameworkBase):
 
     def verifyBenchmarkFile(self, benchmark, filename, is_post):
         pass
-
-    def _updateModelPath(self, model, commands):
-        _args = commands.split()
-        # net_names = {filename: net_type}
-        net_names = {model["files"][key]["filename"]: key for key in model["files"].keys()}
-
-        for i in range(len(_args)):
-            if _args[i] in net_names:
-                _args[i] = os.path.basename(model["files"][net_names[_args[i]]])
-        return ' '.join(_args)


### PR DESCRIPTION
My original changes to benchmark_driver.py were accidentally reverted in #21. This PR reapplies the changes and also updates generic.py to remove the file renaming as it's no longer needed