### PR TITLE
Move rewriting the benchmark file to after the json file is updated

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -62,6 +62,10 @@ class BenchmarkCollector(object):
 
         self._verifyBenchmark(one_benchmark, source, False)
 
+        self._updateFiles(one_benchmark, source)
+
+        self._updateTests(one_benchmark, source)
+
         if meta:
             self._deepMerge(one_benchmark["model"], meta)
         if "commands" in info:
@@ -69,11 +73,6 @@ class BenchmarkCollector(object):
                 one_benchmark["model"]["commands"] = {}
             self._deepMerge(one_benchmark["model"]["commands"],
                             info["commands"])
-
-        self._updateFiles(one_benchmark, source)
-
-        self._updateTests(one_benchmark, source)
-
         # Add fields that should not appear in the saved benchmark file
         # Adding path to benchmark file
         one_benchmark["path"] = os.path.abspath(source)


### PR DESCRIPTION
This is to avoid those rewrite appear in the updated json file. The updated json file should only have the MD5 hash updated.